### PR TITLE
Enhancement: Added support of direct CSV transfer to OMS without FTP

### DIFF
--- a/service/co/hotwax/product/ProductFacilityServices.xml
+++ b/service/co/hotwax/product/ProductFacilityServices.xml
@@ -133,11 +133,56 @@
             <if condition="!csvFilePath">
                 <return message="No products falls under any rule in this rule group."/>
             </if>
+            <set field="file" from="new java.io.File(csvFilePath)"/>
+            <set field="fileName" from="file.getName()"/>
+            <set field="configId" value="IMP_PROD_FACILITY"/>
+            <set field="fileText" from="org.apache.commons.io.FileUtils.readFileToString(file, 'UTF-8')"/>
+            <!--Upload csv directly to OMS with uploadandimportfile api-->
+            <script>
+                import org.moqui.util.RestClient
+                import org.moqui.impl.context.ContextJavaUtil
+                import co.hotwax.util.MaargUtil
 
-            <service-call name="co.hotwax.product.ProductFacilityServices.upload#ProductFacilityCsvToFtp" transaction="force-new"
-                    in-map="[filePath: csvFilePath, systemMessageRemoteId: systemMessageRemoteId]"
-                    out-map="result"/>
+                String omsInstanceUrl = System.getProperty("ofbiz.instance.url");
+                if (omsInstanceUrl == null || omsInstanceUrl.isEmpty()) {
+                EntityValue omsInstance = ecfi.entityFacade.find("moqui.service.message.SystemMessageRemote")
+                .condition("systemMessageRemoteId", "HC_OMS_CONFIG")
+                .useCache(true)
+                .disableAuthz()
+                .one();
+                    if (omsInstance != null &amp;&amp; omsInstance.getString("sendUrl") != null) {
+                    omsInstanceUrl = omsInstance.getString("sendUrl");
+                        }
+                    else {
+                        EntityValue omsInstanceProperty = ecfi.entityFacade.find("org.apache.ofbiz.common.property.SystemProperty")
+                        .condition("systemResourceId", "url")
+                        .condition("systemPropertyId", "content.url.prefix.secure")
+                        .useCache(true)
+                        .disableAuthz()
+                        .one();
+                        if (omsInstanceProperty != null) {
+                        omsInstanceUrl = omsInstanceProperty.getString("systemPropertyValue");
+                        }
+                    }
+                }
+                def endpoint = omsInstanceUrl + "/api/uploadAndImportFile"
+                RestClient restClient = ec.service.rest()
+                restClient.uri(endpoint)
+                .method("POST")
+                .contentType("multipart/form-data")
+                restClient.addFieldPart("configId", configId)
+                restClient.addFieldPart("_uploadedFile_fileName", fileName)
+                restClient.addFieldPart("_uploadedFile_contentType", "text/csv")
+                restClient.addFilePart("uploadedFile", fileName, fileText)
 
+                try {
+                def resp = restClient.call()
+                response = ContextJavaUtil.jacksonMapper.readValue(resp.text(), Map.class)
+                }
+                catch (Exception e) {
+                ec.logger.error("Error uploading file: ${e.getMessage()}")
+                }
+            </script>
             <return message="Product facility rules executed successfully for rule group [${ruleGroupId}]."/>
         </actions>
     </service>


### PR DESCRIPTION
Updated the flow to call the uploadAndImportFile service on OMS directly, instead of uploading the file to an FTP location. Earlier, the file was placed on FTP and then picked up separately by a importproductfacility job on the OMS side. 